### PR TITLE
Исправить правила игры uno

### DIFF
--- a/index.html
+++ b/index.html
@@ -896,20 +896,14 @@
                 playerHand.appendChild(cardElement);
             });
             
-            // Кнопка UNO
+            // Кнопка UNO - всегда видна, но активна только при одной карте
+            const unoButton = document.getElementById('uno-button');
+            unoButton.style.display = 'block';
+            
             if (currentPlayerIndex === 0 && humanPlayer.hand.length === 1 && !humanPlayer.unoSaid) {
-                document.getElementById('uno-button').style.display = 'block';
-                document.getElementById('uno-button').disabled = false;
-                
-                clearTimeout(unoTimeout);
-                unoTimeout = setTimeout(() => {
-                    if (humanPlayer.hand.length === 1 && !humanPlayer.unoSaid) {
-                        document.getElementById('uno-button').disabled = true;
-                    }
-                }, 5000);
+                unoButton.disabled = false;
             } else {
-                document.getElementById('uno-button').style.display = 'none';
-                document.getElementById('uno-button').disabled = true;
+                unoButton.disabled = true;
             }
         }
         
@@ -963,7 +957,6 @@
                     if (currentPlayer.hand.length > 1) {
                         currentPlayer.unoSaid = false;
                         currentPlayer.pendingUno = false;
-                        document.getElementById('uno-button').style.display = 'none';
                     }
                     
                     renderPlayerHand();
@@ -1141,20 +1134,15 @@
             // Обработка UNO
             if (currentPlayer.hand.length === 1 && !currentPlayer.unoSaid) {
                 if (currentPlayer.isHuman) {
-                    // Даем игроку время сказать UNO
-                    currentPlayer.pendingUno = true;
-                    setTimeout(() => {
-                        if (currentPlayer.hand.length === 1 && !currentPlayer.unoSaid && currentPlayer.pendingUno) {
-                            // Игрок забыл сказать UNO - штраф 2 карты
-                            alert(`${currentPlayer.name} забыл сказать UNO! Штраф: +2 карты`);
-                            for (let i = 0; i < 2; i++) {
-                                drawCardForPlayer(currentPlayerIndex);
-                            }
-                            currentPlayer.pendingUno = false;
-                            renderPlayerHand();
-                            renderPlayers();
-                        }
-                    }, 3000); // 3 секунды на то чтобы сказать UNO
+                    // Игрок сделал ход с одной картой, не нажав кнопку UNO - штраф
+                    alert(`${currentPlayer.name} забыл сказать UNO! Штраф: +2 карты`);
+                    for (let i = 0; i < 2; i++) {
+                        drawCardForPlayer(currentPlayerIndex);
+                    }
+                    currentPlayer.unoSaid = false;
+                    currentPlayer.pendingUno = false;
+                    renderPlayerHand();
+                    renderPlayers();
                 } else {
                     // Боты автоматически говорят UNO
                     currentPlayer.unoSaid = true;
@@ -1266,8 +1254,7 @@
                     currentPlayer.pendingUno = false;
                     document.getElementById('uno-button').disabled = true;
                     renderPlayers();
-                    
-                    clearTimeout(unoTimeout);
+                    alert(`${currentPlayer.name} сказал UNO!`);
                 }
             }
         }


### PR DESCRIPTION
Make the "Say UNO" button always visible and apply penalty immediately if a player moves with one card without saying UNO, to align with game rules.

The previous logic hid the button and used a timer for the penalty, which was not the desired behavior. This change ensures the button is always present (though only active when relevant) and penalties are instant for rule violations.

---

[Open in Web](https://cursor.com/agents?id=bc-1da1268b-89a8-4af8-b7b6-40a5820d143a) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-1da1268b-89a8-4af8-b7b6-40a5820d143a) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)